### PR TITLE
Updated README to match current `func` proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ Tel.is({'jack': 4098, 'sape': 4139}); // => true
 Typed functions may be defined like this:
 
 ```javascript
+// add takes two `Num`s and returns a `Num`
 var add = func([Num, Num], Num)
     .of(function (x, y) { return x + y; });
 ```
@@ -554,7 +555,7 @@ Returns a function type whose functions have their domain and codomain specified
 `func` can be used to define function types using native types:
 
 ```javascript
-// An `A` is a `Func` which takes a `Str` and returns an `Num`
+// An `A` takes a `Str` and returns an `Num`
 var A = func(Str, Num);
 ```
 


### PR DESCRIPTION
To document fix to #42.

Tested all the code and proofread. Please let me know if I made any mistakes or if you want to make any changes : ).

I used english definitions of function types rather than normal type signatures so that people new to types can understand it and not get confused that maybe the type signature is part of how to make function types.

E.g.

```
// A `B` takes a `Func` (which takes a `Str` and returns a `Num`) and returns a `Str`.
```

Instead of

```
// B : (Str -> Num) -> Str
```

Maybe it would be better to use the shorter type signatures instead?
