### PR TITLE
Make `Struct.extend` variadic

### DIFF
--- a/index.js
+++ b/index.js
@@ -398,7 +398,7 @@
     };
   
     Struct.extend = function extendStruct(newProps, name) {
-      return struct(mixin(mixin({}, props), newProps), name);
+      return struct([props].concat(newProps).reduce(mixin, {}), name);
     };
 
     return Struct;


### PR DESCRIPTION
This is a convenience for chaining `extend` calls, which is a pattern I noticed myself repeating when sharing subsets of common properties across multiple struct definitions.

Consider this toy example:

``` javascript
var Publishable = { /* properties relating to the published state of a thing */ }
var Editable = { /* properties referring to the editing state of a thing */ }

var User = struct({ /* User specific properties */ }).extend(Editable, 'User');
var Document = struct({ /* Document specific properties */ }).extend(Editable, Publishable, 'Document');
```

What do you think?
