### PR TITLE
numeric types on enums (#93)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.log
+*.swp
 node_modules
 dev
 definitions

--- a/docs/guide/index.html
+++ b/docs/guide/index.html
@@ -303,7 +303,7 @@ Country.is('FR'); // => false
 
           <p>If you don't care of values you can use <code>enums.of(keys, name?)</code> where:</p>
           <ul>
-            <li><code>keys: Array&lt;Str&gt; | Str</code> is the array of enums or a string where the enums are separated by spaces</li>
+            <li><code>keys: Array&lt;Str|Number&gt; | Str</code> is the array of enums or a string where the enums are separated by spaces</li>
             <li><code>name: ?Str</code> is an optional string useful for debugging purposes</li>
           </ul>
           <pre><code>

--- a/index.js
+++ b/index.js
@@ -393,7 +393,7 @@
     Enums.displayName = name;
 
     Enums.is = function (x) {
-      return Str.is(x) && map.hasOwnProperty(x);
+      return map.hasOwnProperty(x);
     };
 
     return Enums;

--- a/test/test.js
+++ b/test/test.js
@@ -1059,15 +1059,21 @@ describe('enums', function () {
       North: 0,
       East: 1,
       South: 2,
-      West: 3
+      West: 3,
+      1: 'North-East',
+      2.5: 'South-East'
     });
 
     it('should return true when x is an instance of the enum', function () {
       ok(Direction.is('North'));
+      ok(Direction.is(1));
+      ok(Direction.is('1'));
+      ok(Direction.is(2.5));
     });
 
     it('should return false when x is not an instance of the enum', function () {
       ko(Direction.is('North-East'));
+      ko(Direction.is(2));
     });
 
   });
@@ -1075,15 +1081,19 @@ describe('enums', function () {
   describe('#of(keys)', function () {
 
     it('should return an enum', function () {
-      var Size = enums.of(['large', 'small']);
+      var Size = enums.of(['large', 'small', 1, 10.9]);
       ok(Size.meta.map.large === 'large');
       ok(Size.meta.map.small === 'small');
+      ok(Size.meta.map['1'] === 1);
+      ok(Size.meta.map[10.9] === 10.9);
     });
 
     it('should handle a string', function () {
-      var Size = enums.of('large small');
+      var Size = enums.of('large small 10');
       ok(Size.meta.map.large === 'large');
       ok(Size.meta.map.small === 'small');
+      ok(Size.meta.map['10'] === '10');
+      ok(Size.meta.map[10] === '10');
     });
 
   });


### PR DESCRIPTION
Relaxing `Str.is(x)` requirement in `enums.is()` (#93)