### PR TITLE
Fix guide example for `t.enums` when used with an array

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -205,7 +205,7 @@ If you don't care of values you can use `enums.of(keys, name?)` where:
 const Country = t.enums.of('IT US', 'Country');
 
 // same as
-const Country = t.enums(['IT', 'US'], 'Country');
+const Country = t.enums.of(['IT', 'US'], 'Country');
 
 // same as
 const Country = t.enums({


### PR DESCRIPTION
`t.enums(['IT', 'US'])` does not work, the current API requires `t.enums.of(<array>)`