### PR TITLE
Fixed malformed function expression in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ tcomb is a library for Node.js and the browser which allows you to **check the t
 var t = require('tcomb');
 
 // a user defined type
-var Integer = t.subtype(t.Number, function (n) => { return n % 1 === 0; }, 'Integer');  // <= give a name for better debug messages
+var Integer = t.subtype(t.Number, function (n) { return n % 1 === 0; }, 'Integer');  // <= give a name for better debug messages
 
 // a struct
 var Person = t.struct({


### PR DESCRIPTION
Looks like it was a combination of a function expression and an arrow function.