### PR TITLE
t.declare([name]) enables construction of recursive types

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -611,6 +611,45 @@ t.func([t.Number, t.Number], t.Number).is(func(t.Number, t.Number).of(id));     
 2. Typed functions' codomains are checked when they return
 3. The domain and codomain of a typed function's type is checked when the typed function is passed to a function type (such as when used as an argument in another typed function)
 
+## Recursive types
+
+`t.declare([name])` declares a type name to be used in other combinators without requiring a definition right away. This enables the construction of recursive or mutually recursive types.
+
+```js
+var Tree = t.declare("Tree");
+
+Tree.define(t.struct({
+  value: t.Num,
+  left: t.maybe(Tree),
+  right: t.maybe(Tree)
+}));
+
+var bst = Tree({
+  value: 5,
+  left: Tree({
+    value: 2
+  }),
+  right: Tree({
+    left: Tree({
+      value: 6
+    }),
+    value: 7
+  })
+});
+```
+
+```js
+var A = t.declare("A");
+
+var B = t.struct({
+  a: t.maybe(A)
+});
+
+A.define(t.struct({
+  b: t.maybe(B)
+});
+```
+
 ## Updating immutable instances
 
 You can update an immutable instance with the provided `update` function:

--- a/index.js
+++ b/index.js
@@ -1018,6 +1018,40 @@ function match(x) {
   exports.fail('Match error');
 }
 
+function declare(name) {
+  if (process.env.NODE_ENV !== 'production') {
+      assert(isTypeName(name), function () { return 'Invalid argument name ' + name + ' supplied to declare([name]) (expected a string)'; });
+  }
+
+  var refcell = {
+    type: null
+  };
+
+  var ret = function Declare(v, path) {
+    if (process.env.NODE_ENV !== 'production') {
+      assert(!!refcell.type, function () { return 'Type declared but not defined, don\'t forget to call .define on every declared type'; });
+    }
+    return refcell.type(v, path);
+  };
+
+  ret.define = function(type) {
+    if (process.env.NODE_ENV !== 'production') {
+      assert(isType(type), function () { return 'Invalid type ' + exports.stringify(type) + ' supplied to define(type) (expected a type)'; });
+      assert(!refcell.type, function () { return 'Declare.define(type) can only be invoked once'; });
+    }
+
+    refcell.type = type;
+    for (var prop in type) {
+      if (type.hasOwnProperty(prop)) {
+        ret[prop] = type[prop];
+      }
+    }
+  };
+
+  ret.displayName = name;
+  return ret;
+}
+
 mixin(exports, {
   is: is,
   isType: isType,
@@ -1057,5 +1091,6 @@ mixin(exports, {
   dict: dict,
   func: func,
   intersection: intersection,
-  match: match
+  match: match,
+  declare: declare
 });

--- a/index.js
+++ b/index.js
@@ -1018,6 +1018,10 @@ function match(x) {
   exports.fail('Match error');
 }
 
+// All the .declare-d types should be clearly different from each other thus they should have
+// different names when a name was not explicitly provided.
+var nextDeclareUniqueId = 1;
+
 function declare(name) {
   if (process.env.NODE_ENV !== 'production') {
     assert(isTypeName(name), function () { return 'Invalid argument name ' + name + ' supplied to declare([name]) (expected a string)'; });
@@ -1036,18 +1040,19 @@ function declare(name) {
     if (process.env.NODE_ENV !== 'production') {
       assert(isType(spec), function () { return 'Invalid argument type ' + exports.stringify(spec) +  ' supplied to define(type) (expected a type)'; });
       assert(isNil(type), function () { return 'Declare.define(type) can only be invoked once'; });
+      assert(isNil(spec.meta.name) && Object.keys(spec.prototype).length === 0, function () { return 'Invalid argument type ' + exports.stringify(spec) + ' supplied to define(type) (expected a fresh, unnamed type)'; });
     }
 
     type = spec;
     mixin(Declare, type, true); // true because it overwrites Declare.displayName
-    if (name) {
-      Declare.meta = mixin({}, Declare.meta);
-      Declare.displayName = Declare.meta.name = name;
-    }
+    Declare.displayName = name || type.displayName;
+    Declare.meta.name = name || Declare.meta.name;
     Declare.prototype = type.prototype;
   };
 
-  Declare.displayName = name;
+  Declare.displayName = name || (getTypeName(Declare) + "$" + nextDeclareUniqueId);
+  Declare.prototype = null;
+  nextDeclareUniqueId += 1;
   return Declare;
 }
 

--- a/index.js
+++ b/index.js
@@ -1020,36 +1020,35 @@ function match(x) {
 
 function declare(name) {
   if (process.env.NODE_ENV !== 'production') {
-      assert(isTypeName(name), function () { return 'Invalid argument name ' + name + ' supplied to declare([name]) (expected a string)'; });
+    assert(isTypeName(name), function () { return 'Invalid argument name ' + name + ' supplied to declare([name]) (expected a string)'; });
   }
 
-  var refcell = {
-    type: null
-  };
+  var type;
 
-  var ret = function Declare(v, path) {
+  function Declare(value, path) {
     if (process.env.NODE_ENV !== 'production') {
-      assert(!!refcell.type, function () { return 'Type declared but not defined, don\'t forget to call .define on every declared type'; });
+      assert(!isNil(type), function () { return 'Type declared but not defined, don\'t forget to call .define on every declared type'; });
     }
-    return refcell.type(v, path);
-  };
+    return type(value, path);
+  }
 
-  ret.define = function(type) {
+  Declare.define = function (spec) {
     if (process.env.NODE_ENV !== 'production') {
-      assert(isType(type), function () { return 'Invalid type ' + exports.stringify(type) + ' supplied to define(type) (expected a type)'; });
-      assert(!refcell.type, function () { return 'Declare.define(type) can only be invoked once'; });
+      assert(isType(spec), function () { return 'Invalid argument type ' + exports.stringify(spec) +  ' supplied to define(type) (expected a type)'; });
+      assert(isNil(type), function () { return 'Declare.define(type) can only be invoked once'; });
     }
 
-    refcell.type = type;
-    for (var prop in type) {
-      if (type.hasOwnProperty(prop)) {
-        ret[prop] = type[prop];
-      }
+    type = spec;
+    mixin(Declare, type, true); // true because it overwrites Declare.displayName
+    if (name) {
+      Declare.meta = mixin({}, Declare.meta);
+      Declare.displayName = Declare.meta.name = name;
     }
+    Declare.prototype = type.prototype;
   };
 
-  ret.displayName = name;
-  return ret;
+  Declare.displayName = name;
+  return Declare;
 }
 
 mixin(exports, {

--- a/test/declare.js
+++ b/test/declare.js
@@ -38,7 +38,7 @@ describe('t.declare([name])', function () {
       throwsWithMessage(function () {
         var D = t.declare("D");
         D.define("not a type");
-      }, '[tcomb] Invalid type "not a type" supplied to define(type) (expected a type)');
+      }, '[tcomb] Invalid argument type "not a type" supplied to define(type) (expected a type)');
 
     });
 

--- a/test/declare.js
+++ b/test/declare.js
@@ -1,0 +1,90 @@
+/* globals describe, it */
+var assert = require('assert');
+var t = require('../index');
+var throwsWithMessage = require('./util').throwsWithMessage;
+
+var A = t.declare("A");
+
+var B = t.struct({
+  a: t.maybe(A)
+});
+
+A.define(t.struct({
+  b: t.maybe(B)
+}));
+
+var aValue = A({
+  b: B({
+    a: A({
+      b: null
+    })
+  })
+});
+
+describe('t.declare([name])', function () {
+
+  describe('combinator', function () {
+
+    it('should throw if used with wrong arguments', function () {
+
+      assert.throws(function () {
+        t.declare(t.Num);
+      }, function(err) {
+        assert.strictEqual(err instanceof Error, true);
+        assert.ok(/\[tcomb\] Invalid argument name function (.|\n)* supplied to declare\(\[name\]\) \(expected a string\)/m.test(err.message));
+        return true;
+      });
+
+      throwsWithMessage(function () {
+        var D = t.declare("D");
+        D.define("not a type");
+      }, '[tcomb] Invalid type "not a type" supplied to define(type) (expected a type)');
+
+    });
+
+    it('should throw if define-d multiple times', function () {
+      throwsWithMessage(function () {
+        var D = t.declare("D");
+        D.define(t.Num);
+        D.define(t.Num);
+      }, '[tcomb] Declare.define(type) can only be invoked once');
+    });
+
+  });
+
+  describe('constructor', function () {
+
+    it('should be idempotent', function () {
+      var p1 = A(aValue);
+      var p2 = A(p1);
+      assert.deepEqual(p2 === p1, true);
+    });
+
+    it('should accept only valid values', function () {
+      throwsWithMessage(function () {
+        A({b: 12});
+      }, '[tcomb] Invalid value 12 supplied to {b: ?{a: ?A}}/b: ?{a: ?A} (expected an object)');
+      throwsWithMessage(function () {
+        A({b: B({ a: 13 }) });
+      }, '[tcomb] Invalid value 13 supplied to {a: ?A}/a: ?A (expected an object)');
+    });
+
+    it('should throw if the type was not defined', function () {
+      throwsWithMessage(function () {
+        var D = t.declare("D");
+        D({a: A({}) });
+      }, '[tcomb] Type declared but not defined, don\'t forget to call .define on every declared type');
+    });
+
+  });
+
+  describe('#is(x)', function () {
+
+    it('should return true when x is an instance of the struct', function () {
+      var a = new A(aValue);
+      assert.ok(A.is(a));
+    });
+
+  });
+
+});


### PR DESCRIPTION
This code contains a proposed pseudo-combinator to enable the construction of recursive types (https://github.com/gcanti/tcomb/issues/71). The proposed API is described in the "Recusive types" section of the GUIDE.

This is a minimal addition that (to my knowledge) doesn't break existing features and does not require changes to the existing combinators. The `displayName` path for unnamed structs sometimes contains the type name (or a placeholder, when an explicit name was not provided) for types constructed via `declare`, e.g.
`{value: Int, b: B}/b: B` where `B` is in fact `{a: A}`. This is mainly due to limitations of the proposed implementation, but - in general - it would anyway not be possible to represent all the (mutually recursive) struct types with their fields (it would not terminate).