### PR TITLE
Prevent Maybe constructor from altering the value when Nil (fixes #183)

### DIFF
--- a/lib/maybe.js
+++ b/lib/maybe.js
@@ -31,7 +31,7 @@ function maybe(type, name) {
     if (process.env.NODE_ENV !== 'production') {
       forbidNewOperator(this, Maybe);
     }
-    return Nil.is(value) ? null : create(type, value, path);
+    return Nil.is(value) ? value : create(type, value, path);
   }
 
   Maybe.meta = {

--- a/test/maybe.js
+++ b/test/maybe.js
@@ -63,7 +63,7 @@ describe('t.maybe(type, [name])', function () {
     it('should hydrate the elements of the maybe in production', util.production(function () {
       var T = t.maybe(Point);
       assert.deepEqual(T(null), null);
-      assert.deepEqual(T(undefined), null);
+      assert.ok(typeof T(undefined) === 'undefined');
       assert.ok(Point.is(T({x: 0, y: 0})));
     }));
 
@@ -84,6 +84,12 @@ describe('t.maybe(type, [name])', function () {
       assert.equal(p0 === p1, false);
       assert.equal(p1 === p2, true);
     }));
+
+    it('should be idempotent on Nil values', function () {
+      var T = t.maybe(t.String, 'T');
+      assert.deepEqual(T(null), null);
+      assert.ok(typeof T(undefined) === 'undefined');
+    });
 
   });
 


### PR DESCRIPTION
As discussed in #183, `maybe(MyType)(x)` currently returns `null` if `Nil.is(x)` returns `true`.

This may surprise users that would expect `maybe(MyType)(undefined)` to return `undefined`.

This PR changes the behavior of the `Maybe` constructor, so that `Nil` values are returned untouched by the constructor.