### PR TITLE
change how struct.extend mixes prototypes

### DIFF
--- a/lib/struct.js
+++ b/lib/struct.js
@@ -16,6 +16,14 @@ function getDefaultName(props) {
   }).join(', ') + '}';
 }
 
+function mixPrototypes (target, source) {
+  Object.getOwnPropertyNames(source).forEach(function (prop) {
+    if (prop === 'constructor') { return; }
+    var descriptor = Object.getOwnPropertyDescriptor(source, prop);
+    Object.defineProperty(target, prop, descriptor);
+  });
+}
+
 function extend(mixins, name) {
   if (process.env.NODE_ENV !== 'production') {
     assert(isArray(mixins) && mixins.every(function (x) {
@@ -23,18 +31,18 @@ function extend(mixins, name) {
     }), function () { return 'Invalid argument mixins supplied to extend(mixins, name), expected an array of objects or structs'; });
   }
   var props = {};
-  var prototype = {};
+  var prototype = Object.create(null);
   mixins.forEach(function (struct) {
     if (isObject(struct)) {
       mixin(props, struct);
     }
     else {
       mixin(props, struct.meta.props);
-      mixin(prototype, struct.prototype);
+      mixPrototypes(prototype, struct.prototype);
     }
   });
   var ret = struct(props, name);
-  mixin(ret.prototype, prototype);
+  mixPrototypes(ret.prototype, prototype);
   return ret;
 }
 


### PR DESCRIPTION
mixes properties defined with `Object.defineProperty`, including getters, setters, and non-enumerable properties.