### PR TITLE
Promise type

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ t.Number = require('./lib/Number');
 t.Integer = require('./lib/Integer');
 t.IntegerT = t.Integer;
 t.Object = require('./lib/Object');
+t.Promise = require('./lib/Promise');
 t.RegExp = require('./lib/RegExp');
 t.String = require('./lib/String');
 t.Type = require('./lib/Type');

--- a/lib/Promise.js
+++ b/lib/Promise.js
@@ -1,0 +1,4 @@
+var irreducible = require('./irreducible');
+var isPromise = require('./isPromise');
+
+module.exports = irreducible('Promise', isPromise);

--- a/lib/isPromise.js
+++ b/lib/isPromise.js
@@ -1,0 +1,5 @@
+var isFunction = require('./isFunction');
+
+module.exports = function isPromise(x) {
+  return !!x && isFunction(x.then);
+};

--- a/test/irreducibles.js
+++ b/test/irreducibles.js
@@ -60,7 +60,8 @@ describe('irreducibles types', function () {
     {T: t.Function, x: noop},
     {T: t.Error, x: new Error()},
     {T: t.RegExp, x: /a/},
-    {T: t.Date, x: new Date()}
+    {T: t.Date, x: new Date()},
+    {T: t.Promise, x: { then: function() {} }}
   ].forEach(function (o) {
 
     var T = o.T;
@@ -363,6 +364,37 @@ describe('t.Type', function () {
     it('should return true if x is a tcomb type', function () {
       assert.equal(t.Type.is(t.String), true);
       assert.equal(t.Type.is(1), false);
+    });
+
+  });
+
+});
+
+
+describe('t.Promise', function () {
+
+  describe('#is(x)', function () {
+
+    it('should return true when x is a Promise', function () {
+      assert.ok(t.Promise.is(Promise.resolve()));
+      assert.ok(t.Promise.is(new Promise(function() {})));
+      assert.ok(t.Promise.is({ then: function() {} }));
+    });
+
+    it('should return false when x is not a function', function () {
+      ko(t.Promise.is(null));
+      ko(t.Promise.is(undefined));
+      ko(t.Promise.is(0));
+      ko(t.Promise.is(''));
+      ko(t.Promise.is([]));
+      ko(t.Promise.is({}));
+      ko(t.Promise.is(new String('1'))); // eslint-disable-line
+      ko(t.Promise.is(new Number(1))); // eslint-disable-line
+      ko(t.Promise.is(new Boolean())); // eslint-disable-line
+      ko(t.Promise.is(/a/));
+      ko(t.Promise.is(new RegExp('a')));
+      ko(t.Promise.is(new Error()));
+      ko(t.Promise.is(new Date()));
     });
 
   });


### PR DESCRIPTION
When using [`bluebird`](https://www.npmjs.com/package/bluebird) for example, we can't use `x instanceof Promise` to check if it is a Promise. This is a Type that works with all promises and thenables ([`“promise” is an object or function with a then method whose behavior conforms to this specification.`](https://promisesaplus.com/))