### PR TITLE
feat(refinement. irreducible): add optional args

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,10 +25,11 @@ declare module Tcomb {
       name: string;
       identity: boolean;
       predicate: TypeGuardPredicate<T>;
+      args: any;
     };
   }
 
-  export function irreducible<T>(name: string, predicate: Predicate<any>): Irreducible<T>;
+  export function irreducible<T>(name: string, predicate: Predicate<any>, args?: any): Irreducible<T>;
 
   //
   // basic types
@@ -72,11 +73,12 @@ declare module Tcomb {
       identity: boolean;
       type: Constructor<T>;
       predicate: TypeGuardPredicate<T>;
+      args: any;   
     };
     update: Update<T>;
   }
 
-  export function refinement<T>(type: Constructor<T>, predicate: Predicate<T>, name?: string): Refinement<T>;
+  export function refinement<T>(type: Constructor<T>, predicate: Predicate<T>, name?: string, args?: any): Refinement<T>;
 
   //
   // struct

--- a/lib/irreducible.js
+++ b/lib/irreducible.js
@@ -3,7 +3,7 @@ var isString = require('./isString');
 var isFunction = require('./isFunction');
 var forbidNewOperator = require('./forbidNewOperator');
 
-module.exports = function irreducible(name, predicate) {
+module.exports = function irreducible(name, predicate, args) {
 
   if (process.env.NODE_ENV !== 'production') {
     assert(isString(name), function () { return 'Invalid argument name ' + assert.stringify(name) + ' supplied to irreducible(name, predicate) (expected a string)'; });
@@ -25,6 +25,7 @@ module.exports = function irreducible(name, predicate) {
     kind: 'irreducible',
     name: name,
     predicate: predicate,
+    args: args,
     identity: true
   };
 

--- a/lib/refinement.js
+++ b/lib/refinement.js
@@ -12,7 +12,7 @@ function getDefaultName(type, predicate) {
   return '{' + getTypeName(type) + ' | ' + getFunctionName(predicate) + '}';
 }
 
-function refinement(type, predicate, name) {
+function refinement(type, predicate, name, args) {
 
   if (process.env.NODE_ENV !== 'production') {
     assert(isFunction(type), function () { return 'Invalid argument type ' + assert.stringify(type) + ' supplied to refinement(type, predicate, [name]) combinator (expected a type)'; });
@@ -46,6 +46,7 @@ function refinement(type, predicate, name) {
     type: type,
     predicate: predicate,
     name: name,
+    args: args,
     identity: identity
   };
 


### PR DESCRIPTION
Hi, I create https://github.com/typeetfunc/runtypes-generate. This project allows generating random data from runtypes type via [jsverify](https://github.com/jsverify/jsverify). Now I work on similar project `tcomb-generate` for tcomb. Related issue:  https://github.com/gcanti/tcomb/issues/263
Optional args for refinement and irreducible type(i.e. predicate types) allows creating custom parameterized generator in tests for custom predicate type. See example: https://github.com/typeetfunc/runtypes-generate/blob/master/src/custom.spec.ts#L35
Also, what do you think about this feature(generating data from type)? 
