### PR TITLE
add function support to defaultProps

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -227,6 +227,21 @@ const Point = t.struct({
 
 // point is immutable, the new keyword is optional
 const point = Point({ x: 1, y: 2 });
+
+const Point3D = t.struct({
+  x: t.Number,
+  y: t.Number,
+  z: t.Number
+}, {
+  name: 'Point3D',
+  defaultProps: {
+    y: 2,
+    z: function() { return 3; }    
+  }
+})
+
+// point now have the values {x: 1, y: 2, z: 3}
+const point = Point({ x: 1 });
 ```
 
 **Note**. `Point.is` internally uses `instanceof`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -98,7 +98,8 @@ interface Struct<T> extends Type<T> {
 
 type StructOptions = {
   name?: string,
-  strict?: boolean
+  strict?: boolean,
+  defaultProps?: Object
 };
 
 export function struct<T>(props: StructProps, name?: string | StructOptions): Struct<T>;

--- a/lib/struct.js
+++ b/lib/struct.js
@@ -5,6 +5,7 @@ var Function = require('./Function');
 var isBoolean = require('./isBoolean');
 var isObject = require('./isObject');
 var isNil = require('./isNil');
+var isFunction = require('./isFunction');
 var create = require('./create');
 var getTypeName = require('./getTypeName');
 var dict = require('./dict');
@@ -77,7 +78,7 @@ function struct(props, options) {
         var actual = value[k];
         // apply defaults
         if (actual === undefined) {
-          actual = defaultProps[k];
+          actual = isFunction(defaultProps[k]) ? defaultProps[k]() : defaultProps[k];
         }
         this[k] = create(expected, actual, ( process.env.NODE_ENV !== 'production' ? path.concat(k + ': ' + getTypeName(expected)) : null ));
       }

--- a/test/struct.js
+++ b/test/struct.js
@@ -164,8 +164,9 @@ describe('t.struct(props, [name])', function () {
     it('should handle the defaultProps option', function () {
       var T = t.struct({
         name: t.String,
-        surname: t.String
-      }, { defaultProps: { surname: 'Canti' } });
+        surname: t.String,
+        number: t.Number
+      }, { defaultProps: { surname: 'Canti', number: function() { return 1; }} });
       assert.doesNotThrow(function () {
         T({ name: 'Giulio' });
       });


### PR DESCRIPTION
I'm using 3.2.24

I found this pretty useful for things like this

```
const Sample = t.struct({
  type: t.String,
  createdAt: t.Date
}, {
  defaultProps: {
    type: 'SAMPLE',
    createdAt: function() {
      return new Date();
    }
  }
});
```