### PR TITLE
fix(struct): typescript signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,8 +57,7 @@ type Command = ApplyCommand | PushCommand | RemoveCommand | SetCommand | SpliceC
 type UpdatePatch = Command | { [key: string]: UpdatePatch };
 type Update<T> = (instance: T, spec: UpdatePatch) => T;
 
-type Con
-                            or<T> = Type<T> | Function;
+type Constructor<T> = Type<T> | Function;
 
 //
 // refinement

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,7 +57,8 @@ type Command = ApplyCommand | PushCommand | RemoveCommand | SetCommand | SpliceC
 type UpdatePatch = Command | { [key: string]: UpdatePatch };
 type Update<T> = (instance: T, spec: UpdatePatch) => T;
 
-type Constructor<T> = Type<T> | Function;
+type Con
+                            or<T> = Type<T> | Function;
 
 //
 // refinement
@@ -91,14 +92,16 @@ interface Struct<T> extends Type<T> {
     identity: boolean;
     props: StructProps;
     strict: boolean;
+    defaultProps: object;
   };
   update: Update<T>;
-  extend<E extends T>(mixins: StructMixin | Array<StructMixin>, name?: string): Struct<E>;
+  extend<E extends T>(mixins: StructMixin | Array<StructMixin>, name?: string | StructOptions): Struct<E>;
 }
 
 type StructOptions = {
   name?: string,
-  strict?: boolean
+  strict?: boolean,
+  defaultProps? object
 };
 
 export function struct<T>(props: StructProps, name?: string | StructOptions): Struct<T>;


### PR DESCRIPTION
The type definition for `struct` is out of date. This fixes it.

### Extend type signature
The extend method also does not have the correct type, as we can actually pass `StructOptions` to extend rather than a simple string. For example, this is currently giving the error:
```js
const a = t.struct({ foo: t.string });
const b = a.extend({ bar: t.string }, { name: 'b', strict: true }); 
```

### defaultProps missing from StructOptions
`defaultProps` is not present in the StructOptions, this is incorrect. For example, this throws an error:
```js
const a = t.struct({ foo: t.string }, { defaultProps: { foo: 'bar' }});