### PR TITLE
fix: broken typescript signature for struct

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,7 @@ interface Struct<T> extends Type<T> {
 type StructOptions = {
   name?: string,
   strict?: boolean,
-  defaultProps? object
+  defaultProps?: object
 };
 
 export function struct<T>(props: StructProps, name?: string | StructOptions): Struct<T>;


### PR DESCRIPTION
In my previous pull request #317, I have missed a colon off which broke the type definition! Sorry about that :)