### PR TITLE
Fix: Enums.is() with an array value should always be false

### DIFF
--- a/lib/enums.js
+++ b/lib/enums.js
@@ -1,6 +1,7 @@
 var assert = require('./assert');
 var isTypeName = require('./isTypeName');
 var forbidNewOperator = require('./forbidNewOperator');
+var isNumber = require('./isNumber');
 var isString = require('./isString');
 var isObject = require('./isObject');
 
@@ -38,7 +39,7 @@ function enums(map, name) {
   Enums.displayName = displayName;
 
   Enums.is = function (x) {
-    return map.hasOwnProperty(x);
+    return (isString(x) || isNumber(x)) && map.hasOwnProperty(x);
   };
 
   return Enums;

--- a/test/enums.js
+++ b/test/enums.js
@@ -61,6 +61,7 @@ describe('t.enums(map, [name])', function () {
     it('should return false when x is not an instance of the enum', function () {
       assert.strictEqual(Direction.is('North-East'), false);
       assert.strictEqual(Direction.is(2), false);
+      assert.strictEqual(Direction.is(['North']), false);
     });
 
   });
@@ -82,7 +83,6 @@ describe('t.enums(map, [name])', function () {
       assert.ok(Size.meta.map['10'] === '10');
       assert.ok(Size.meta.map[10] === '10');
     });
-
   });
 
 });


### PR DESCRIPTION
Javascript oddity: `true === {p: 'v'}.hasOwnProperty(['p'])`.
    
In ancient times, the checked value was also ensured to be a String.
This was removed with #94 (`Enums` supports numbers).

Note: With this fix, valid `Enums` values are restricted to the
officially supported types `Number` and `String`. The previous
implementation could have worked also for `Symbol`.